### PR TITLE
Support multiple decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,13 @@ The class decorators are used infront of the class declaration and do not suppor
 export class User {}
 ```
 
-> Tip: Make sure you import `JsonObject` from `json2typescript`.
+> Tip: Make sure you import `JsonObject` from `json2typescript`.  
+> Tip: It's possible to deserialize multiple JSON-values into the same property. This can be useful if you have multiple JSON sources with inconsistent names, but want a single target object.
+```typescript
+    @JsonProperty("jsonPropName", String, true)
+    @JsonProperty("jsonPropertyName", String, true)
+    name: string = undefined;
+```
 
 ### Property decorators
 

--- a/src/json2typescript/json-convert-decorators.ts
+++ b/src/json2typescript/json-convert-decorators.ts
@@ -60,7 +60,7 @@ export function JsonProperty(jsonPropertyName?: string, conversionOption?: any, 
 
         let jsonPropertyMappingOptions = new MappingOptions();
         jsonPropertyMappingOptions.classPropertyName = classPropertyName;
-        jsonPropertyMappingOptions.jsonPropertyName = jsonPropertyName;
+        jsonPropertyMappingOptions.jsonPropertyName.push(jsonPropertyName);
         jsonPropertyMappingOptions.isOptional = isOptional ? isOptional : false;
 
         // Check if conversionOption is a type or a custom converter.
@@ -71,7 +71,13 @@ export function JsonProperty(jsonPropertyName?: string, conversionOption?: any, 
         }
 
         // Save the mapping info
-        target[Settings.MAPPING_PROPERTY][classPropertyName] = jsonPropertyMappingOptions;
+        if (typeof target[Settings.MAPPING_PROPERTY][classPropertyName] === 'undefined') {
+            // First decorator for this classProperty
+            target[Settings.MAPPING_PROPERTY][classPropertyName] = jsonPropertyMappingOptions;
+        } else {
+            // Second decorator - just add the alternative JSON-name for this classProperty
+            target[Settings.MAPPING_PROPERTY][classPropertyName].jsonPropertyName.push(jsonPropertyName);
+        }
 
     }
 

--- a/src/json2typescript/json-convert-options.ts
+++ b/src/json2typescript/json-convert-options.ts
@@ -11,7 +11,7 @@ export class Settings {
  */
 export class MappingOptions {
     classPropertyName: string = "";
-    jsonPropertyName: string = "";
+    jsonPropertyName: string[] = [];
     expectedJsonType: string = undefined;
     isOptional: boolean = false;
     customConverter: any = null;


### PR DESCRIPTION
An implementation to support multiple decorators during deserialization.
I've had a usecase my JSON-source used different propertyNames for conceptually equal properties across different API calls.

Happy to make any changes as you see fit of course